### PR TITLE
Add support for ignoring some templates in the template list

### DIFF
--- a/src/main/java/uk/ac/imperial/libhpc2/schemaservice/TempssObject.java
+++ b/src/main/java/uk/ac/imperial/libhpc2/schemaservice/TempssObject.java
@@ -62,6 +62,13 @@ public class TempssObject {
         this._schema = schema;
         this._transform = transform;
     }
+    
+    public TempssObject(TempssObject pObj) {
+    	this._id = pObj.getId();
+        this._name = pObj.getName();
+        this._schema = pObj.getSchema();
+        this._transform = pObj.getTransform();
+    }
 
     public String getId() {
         return _id;

--- a/src/main/java/uk/ac/imperial/libhpc2/schemaservice/api/TemplateRestResource.java
+++ b/src/main/java/uk/ac/imperial/libhpc2/schemaservice/api/TemplateRestResource.java
@@ -45,11 +45,16 @@
 
 package uk.ac.imperial.libhpc2.schemaservice.api;
 
+import java.io.BufferedReader;
+import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.FileReader;
 import java.io.IOException;
 import java.text.ParseException;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
-import java.util.logging.Logger;
+import java.util.Set;
 
 import javax.servlet.ServletContext;
 import javax.ws.rs.GET;
@@ -65,6 +70,8 @@ import javax.xml.transform.TransformerException;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import uk.ac.imperial.libhpc2.schemaservice.SchemaProcessor;
@@ -82,7 +89,7 @@ public class TemplateRestResource {
     /**
      * Logger
      */
-    private static final Logger sLog = Logger.getLogger(TemplateRestResource.class.getName());
+    private static final Logger sLog = LoggerFactory.getLogger(TemplateRestResource.class.getName());
 
     /**
      * ServletContext obejct used to access template data
@@ -93,15 +100,44 @@ public class TemplateRestResource {
     @Context
     public void setServletContext(ServletContext pContext) {
         this._context = pContext;
-        sLog.fine("Servlet context injected: " + pContext);
+        sLog.debug("Servlet context injected: " + pContext);
     }
 
     @GET
     @Produces("application/json")
     @SuppressWarnings("unchecked")
     public Response listTemplatesJson() {
-        Map<String, TempssObject> components = (Map<String, TempssObject>)_context.getAttribute("components");
-
+        Map<String, TempssObject> contextComponents = (Map<String, TempssObject>)_context.getAttribute("components");
+        // Clone the map so we're working with a copy in case we need to 
+        // remove elements from it
+        Map<String, TempssObject> components = 
+        		new HashMap<String, TempssObject>(contextComponents);
+        for(String key : contextComponents.keySet()) {
+        	TempssObject tObj = contextComponents.get(key);
+        	components.put(key, new TempssObject(tObj));
+        }
+        
+        // See if we have a ~/.libhpc/tempss-ignore file listing template IDs
+        // that should be ignored. If we do, then filter out the templates that
+        // we don't want to show.
+        File userHome = new File(System.getProperty("user.home"));
+        File libhpcDir = new File(userHome, ".libhpc");
+        File templateIgnore = new File(libhpcDir, "tempss-ignore");
+        if(templateIgnore.exists()) {
+        	sLog.debug("Found a template ignore file, updating visible " +
+        			"templates");        	
+        	try {
+        		_updateTemplateList(components, templateIgnore);
+        	} catch(FileNotFoundException e) {
+        		
+        	} catch(IOException e) {
+        		
+        	}
+        }
+        else {
+        	sLog.debug("No templates to ignore, returning full template list.");
+        }
+        
         JSONArray componentList = new JSONArray();
         for(TempssObject component : components.values()) {
             JSONObject componentObj = new JSONObject();
@@ -111,7 +147,7 @@ public class TemplateRestResource {
                 componentObj.put("schema", component.getSchema());
                 componentObj.put("transform", component.getTransform());
             } catch (JSONException e) {
-                sLog.severe("Unable to add component data <" + component.toString() + "> to JSON object: " + e.getMessage());
+                sLog.error("Unable to add component data <" + component.toString() + "> to JSON object: " + e.getMessage());
                 return Response.status(Status.INTERNAL_SERVER_ERROR).entity("Unable to add component data <" + component.toString() + "> to JSON object: " + e.getMessage()).build();
             }
 
@@ -121,7 +157,7 @@ public class TemplateRestResource {
         try {
             componentArray.put("components", componentList);
         } catch (JSONException e) {
-            sLog.severe("Unable to add component array to component object: " + e.getMessage());
+            sLog.error("Unable to add component array to component object: " + e.getMessage());
             return Response.status(Status.INTERNAL_SERVER_ERROR).entity("Unable to add component array to component object: " + e.getMessage()).build();
         }
 
@@ -223,19 +259,46 @@ public class TemplateRestResource {
         try {
             htmlTree = proc.processComponentSelector(metadata);
         } catch (FileNotFoundException e) {
-            sLog.severe("File not found when trying to generate HTML tree: " + e.getMessage());
+            sLog.error("File not found when trying to generate HTML tree: " + e.getMessage());
             return Response.status(Status.INTERNAL_SERVER_ERROR).entity("File not found when trying to generate HTML tree: " + e.getMessage()).build();
         } catch (IOException e) {
-            sLog.severe("IO error when trying to generate HTML tree: " + e.getMessage());
+            sLog.error("IO error when trying to generate HTML tree: " + e.getMessage());
             return Response.status(Status.INTERNAL_SERVER_ERROR).entity("IO error when trying to generate HTML tree: " + e.getMessage()).build();
         } catch (ParseException e) {
-            sLog.severe("XML parse error when trying to generate HTML tree: " + e.getMessage());
+            sLog.error("XML parse error when trying to generate HTML tree: " + e.getMessage());
             return Response.status(Status.INTERNAL_SERVER_ERROR).entity("XML parse error when trying to generate HTML tree: " + e.getMessage()).build();
         } catch (TransformerException e) {
-            sLog.severe("XSLT transform error when trying to generate HTML tree: " + e.getMessage());
+            sLog.error("XSLT transform error when trying to generate HTML tree: " + e.getMessage());
             return Response.status(Status.INTERNAL_SERVER_ERROR).entity("XSLT transform error when trying to generate HTML tree: " + e.getMessage()).build();
         }
 
         return Response.ok(htmlTree, MediaType.TEXT_HTML).build();
+    }
+    
+    private void _updateTemplateList(
+    		Map<String, TempssObject> pComponents, File pIgnoreFile) 
+    				throws FileNotFoundException, IOException {
+    	
+    	BufferedReader reader = new BufferedReader(new FileReader(pIgnoreFile));
+    	String line = null;
+    	Set<String> removeSet = new HashSet<String>();
+    	Set<String> keys = pComponents.keySet();
+    	while((line = reader.readLine()) != null) {
+    		sLog.debug("Processing ignore pattern: <{}>", line);
+    		if(line.endsWith("*")) {
+    			String searchValue = line.substring(0, line.length()-1);
+    			sLog.debug("Ignoring components beginning with <{}>", searchValue);
+    			for(String key : keys) {
+    				if(key.startsWith(searchValue)) {
+    					removeSet.add(key);
+    				}
+    			}
+    		}
+    		else {
+    			removeSet.add(line);
+    		}
+    	}
+    	reader.close();
+    	keys.removeAll(removeSet);
     }
 }

--- a/src/main/webapp/assets/js/tempss-manager.js
+++ b/src/main/webapp/assets/js/tempss-manager.js
@@ -29,12 +29,12 @@ function updateTemplateList() {
 		    	// based on ID
 		    	var components = data.components;
 		    	components.sort(function(item1, item2) {
-		    		return item1.id.localeCompare(item2.id);
+		    		return item1.name.localeCompare(item2.name);
 		    	});
 		    	components.sort();
 		    	for(var i = 0; i < components.length; i++) {
 		    		var item = components[i];
-		    		templateSelect.append("<option value=\"" + item.id + "\">" + item.id + " - " + item.name + "</option>");
+		    		templateSelect.append("<option value=\"" + item.id + "\">" + item.name + " (id: " + item.id + ")</option>");
 		    	}
 		        $("#template-loading").hide(0);
 			},

--- a/src/main/webapp/assets/js/tempss-manager.js
+++ b/src/main/webapp/assets/js/tempss-manager.js
@@ -24,8 +24,16 @@ function updateTemplateList() {
 				// Remove current content excluding the placeholder
 		    	$('#template-select option:gt(0)').remove();
 		    	var templateSelect = $('#template-select');
-		    	for(var i = 0; i < data.components.length; i++) {
-		    		var item = data.components[i];
+		    	
+		    	// Set up a sort function and sort the list of components
+		    	// based on ID
+		    	var components = data.components;
+		    	components.sort(function(item1, item2) {
+		    		return item1.id.localeCompare(item2.id);
+		    	});
+		    	components.sort();
+		    	for(var i = 0; i < components.length; i++) {
+		    		var item = components[i];
 		    		templateSelect.append("<option value=\"" + item.id + "\">" + item.id + " - " + item.name + "</option>");
 		    	}
 		        $("#template-loading").hide(0);


### PR DESCRIPTION
Where many default templates are provided with TemPSS, administrators may wish to configure TemPSS to only display some of these templates in the list of available templates. This update adds support for a tempss-ignore file that allows some templates to be hidden from the list of available templates at runtime. This file is checked on every request for a list of the available templates so changes are reflected dynamically.

This change also alters the display of templates in the list using the name as the main display parameter with the id shown in parentheses. Items are now sorted into alphabetical order.