### PR TITLE
Fixed some compile warnings 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,9 @@
 	<version>0.0.1-SNAPSHOT</version>
 	<name>TemPSS Maven Webapp</name>
 	<url>http://maven.apache.org</url>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>junit</groupId>

--- a/src/main/java/uk/ac/imperial/libhpc2/schemaservice/SchemaProcessorServlet.java
+++ b/src/main/java/uk/ac/imperial/libhpc2/schemaservice/SchemaProcessorServlet.java
@@ -162,6 +162,7 @@ public class SchemaProcessorServlet extends HttpServlet {
      * @throws ServletException if problem
      * @throws IOException if problem
      */
+    @SuppressWarnings("unchecked")
     public void doPost(HttpServletRequest req, HttpServletResponse resp)
             throws ServletException, IOException {
 

--- a/src/main/java/uk/ac/imperial/libhpc2/schemaservice/web/dao/impl/JdbcProfileDaoImpl.java
+++ b/src/main/java/uk/ac/imperial/libhpc2/schemaservice/web/dao/impl/JdbcProfileDaoImpl.java
@@ -49,17 +49,14 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import javax.sql.DataSource;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.stereotype.Repository;
 
 import uk.ac.imperial.libhpc2.schemaservice.web.dao.ProfileDao;
 import uk.ac.imperial.libhpc2.schemaservice.web.db.Profile;
@@ -80,7 +77,7 @@ public class JdbcProfileDaoImpl implements ProfileDao {
 	
 	@Override
 	public int add(Profile pProfile) {
-		boolean pub = new Boolean(pProfile.getPublic());
+		boolean pub = pProfile.getPublic();
 		Map<String,String> rowParams = new HashMap<String, String>(5);
 		rowParams.put("name", pProfile.getName());
 		rowParams.put("templateId", pProfile.getTemplateId());


### PR DESCRIPTION
This PR fixes a few warnings that were appearing in the compilation process:

 - Resolved an encoding warning by setting the encoding in `pom.xml`
 - Suppressed unchecked cast warnings when accessing attributes stored in the `ServletContext` and converting them to their relevant types
 - Removed use of deprecated `Boolean` constructor